### PR TITLE
MYLUTECEDATABASE-55 : Fix core dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>fr.paris.lutece</groupId>
+            <artifactId>lutece-core</artifactId>
+            <version>[4.4.0,6.0.0-SNAPSHOT)</version>
+            <type>lutece-core</type>
+        </dependency>
+        <dependency>
             <groupId>fr.paris.lutece.plugins</groupId>
             <artifactId>plugin-mylutece</artifactId>
             <version>[3.1.1,)</version>

--- a/webapp/WEB-INF/plugins/mylutece-database.xml
+++ b/webapp/WEB-INF/plugins/mylutece-database.xml
@@ -12,8 +12,8 @@
    <icon-url>images/admin/skin/plugins/mylutece/mylutece.png</icon-url>
    <copyright>Copyright 2001-2014 Mairie de Paris</copyright>
    <core-version-dependency>
-		<min-core-version>4.3.0</min-core-version>
-		<max-core-version/>	
+		<min-core-version>4.4.0</min-core-version>
+		<max-core-version>6</max-core-version>
    </core-version-dependency>
 	
 	<!-- if the plugin must have a connection pool with parameter : 1 - yes, 0 - no -->   


### PR DESCRIPTION
lutece-core 6.0.0-SNAPSHOT broke compatibility with this module
by removing a property. State that in the pom and the plugin xml
description file.