### PR TITLE
MYLUTECEDATABASE-57 : Securely store user passwords

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>fr.paris.lutece.plugins</groupId>
     <artifactId>module-mylutece-database</artifactId>
     <packaging>lutece-plugin</packaging>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <name>Lutece mylutece database module</name>
 
     <repositories>
@@ -23,6 +23,12 @@
     </repositories>
 
     <dependencies>
+        <dependency>
+            <groupId>fr.paris.lutece</groupId>
+            <artifactId>lutece-core</artifactId>
+            <version>[6.0.0-SNAPSHOT,)</version>
+            <type>lutece-core</type>
+        </dependency>
         <dependency>
             <groupId>fr.paris.lutece.plugins</groupId>
             <artifactId>plugin-mylutece</artifactId>

--- a/src/java/fr/paris/lutece/plugins/mylutece/modules/database/authentication/business/IDatabaseUserDAO.java
+++ b/src/java/fr/paris/lutece/plugins/mylutece/modules/database/authentication/business/IDatabaseUserDAO.java
@@ -34,6 +34,7 @@
 package fr.paris.lutece.plugins.mylutece.modules.database.authentication.business;
 
 import fr.paris.lutece.portal.service.plugin.Plugin;
+import fr.paris.lutece.util.password.IPassword;
 
 import java.sql.Timestamp;
 
@@ -58,10 +59,10 @@ public interface IDatabaseUserDAO
      * Insert a new record in the table.
      *
      * @param databaseUser The databaseUser object
-     * @param strPassword The user password
+     * @param password The user password
      * @param plugin The Plugin using this data access service
      */
-    void insert( DatabaseUser databaseUser, String strPassword, Plugin plugin );
+    void insert( DatabaseUser databaseUser, IPassword password, Plugin plugin );
 
     /**
      * Load the data of DatabaseUser from the table
@@ -89,10 +90,10 @@ public interface IDatabaseUserDAO
     /**
      * Update the record in the table
      * @param databaseUser The reference of databaseUser
-     * @param strNewPassword The new password to store
+     * @param newPassword The new password to store
      * @param plugin The Plugin using this data access service
      */
-    void updatePassword( DatabaseUser databaseUser, String strNewPassword, Plugin plugin );
+    void updatePassword( DatabaseUser databaseUser, IPassword newPassword, Plugin plugin );
 
     /**
      * Update the record in the table
@@ -101,15 +102,6 @@ public interface IDatabaseUserDAO
      * @param plugin The Plugin using this data access service
      */
     void updateResetPassword( DatabaseUser databaseUser, boolean bNewValue, Plugin plugin );
-
-    /**
-     * Load the password of the specified user
-     *
-     * @param nDatabaseUserId The Primary key of the databaseUser
-     * @param plugin The current plugin using this method
-     * @return String the user password
-     */
-    String selectPasswordByPrimaryKey( int nDatabaseUserId, Plugin plugin );
 
     /**
      * Load the list of databaseUsers
@@ -135,14 +127,13 @@ public interface IDatabaseUserDAO
     Collection<DatabaseUser> selectDatabaseUserListForEmail( String strEmail, Plugin plugin );
 
     /**
-     * Check the password for a DatabaseUser
+     * load the password for a DatabaseUser
      *
      * @param strLogin The user login of DatabaseUser
-     * @param strPassword The password of DatabaseUser
      * @param plugin The Plugin using this data access service
-     * @return true if password is ok
+     * @return the stored password of the user
      */
-    boolean checkPassword( String strLogin, String strPassword, Plugin plugin );
+    IPassword loadPassword( String strLogin, Plugin plugin );
 
     /**
      * Load the list of DatabaseUsers by a filter
@@ -166,7 +157,7 @@ public interface IDatabaseUserDAO
      * @param plugin The plugin
      * @return The collection of recent passwords used by the user.
      */
-    List<String> selectUserPasswordHistory( int nUserID, Plugin plugin );
+    List<IPassword> selectUserPasswordHistory( int nUserID, Plugin plugin );
 
     /**
      * Get the number of password change done by a user since the given date.
@@ -179,11 +170,11 @@ public interface IDatabaseUserDAO
 
     /**
      * Log a password change in the password history
-     * @param strPassword New password of the user
+     * @param password New password of the user
      * @param nUserId Id of the user
      * @param plugin The plugin
      */
-    void insertNewPasswordInHistory( String strPassword, int nUserId, Plugin plugin );
+    void insertNewPasswordInHistory( IPassword password, int nUserId, Plugin plugin );
 
     /**
      * Remove every password saved in the password history for a user.

--- a/src/java/fr/paris/lutece/plugins/mylutece/modules/database/authentication/service/parameter/DatabaseUserParameterService.java
+++ b/src/java/fr/paris/lutece/plugins/mylutece/modules/database/authentication/service/parameter/DatabaseUserParameterService.java
@@ -41,10 +41,8 @@ import fr.paris.lutece.portal.service.spring.SpringContextService;
 import fr.paris.lutece.util.ReferenceItem;
 import fr.paris.lutece.util.ReferenceList;
 
-import org.apache.commons.lang.StringUtils;
-
 import java.sql.Timestamp;
-
+import java.util.Collections;
 import java.util.List;
 
 
@@ -58,8 +56,6 @@ public final class DatabaseUserParameterService implements IDatabaseUserParamete
     private static final String BEAN_DATABASE_USER_PARAMETER_SERVICE = "mylutece-database.databaseUserParameterService";
 
     // PARAMETERS
-    private static final String PARAMETER_ENABLE_PASSWORD_ENCRYPTION = "enable_password_encryption";
-    private static final String PARAMETER_ENCRYPTION_ALGORITHM = "encryption_algorithm";
     private static final String PARAMETER_ACCOUNT_CREATION_VALIDATION_EMAIL = "account_creation_validation_email";
     private static final String PARAMETER_ENABLE_JCAPTCHA = "enable_jcaptcha";
     private static final String PARAMETER_AUTO_LOGIN_AFTER_VALIDATION_EMAIL = "auto_login_after_validation_email";
@@ -117,19 +113,12 @@ public final class DatabaseUserParameterService implements IDatabaseUserParamete
     /**
      * Check if the passwords must be encrypted or not
      * @param plugin the plugin
-     * @return true if they are encrypted, false otherwise
+     * @return <code>false</code>. Passwords are in fact salted and hashed, but we don't want
+     * plugin-mylutece to try and hash the password itself
      */
     public boolean isPasswordEncrypted( Plugin plugin )
     {
-        boolean bIsPasswordEncrypted = false;
-        ReferenceItem userParam = findByKey( PARAMETER_ENABLE_PASSWORD_ENCRYPTION, plugin );
-
-        if ( ( userParam != null ) && userParam.isChecked(  ) )
-        {
-            bIsPasswordEncrypted = true;
-        }
-
-        return bIsPasswordEncrypted;
+        return false;
     }
 
     /**
@@ -139,15 +128,7 @@ public final class DatabaseUserParameterService implements IDatabaseUserParamete
      */
     public String getEncryptionAlgorithm( Plugin plugin )
     {
-        String strAlgorithm = StringUtils.EMPTY;
-        ReferenceItem userParam = findByKey( PARAMETER_ENCRYPTION_ALGORITHM, plugin );
-
-        if ( userParam != null )
-        {
-            strAlgorithm = userParam.getName(  );
-        }
-
-        return strAlgorithm;
+        return "";
     }
 
     /**
@@ -219,6 +200,7 @@ public final class DatabaseUserParameterService implements IDatabaseUserParamete
     @Override
     public List<String> selectUserPasswordHistory( int nUserID, Plugin plugin )
     {
-        return DatabaseUserHome.selectUserPasswordHistory( nUserID, plugin );
+        // the way we store password is incompatible with this function specified by plugin-mulutece
+        return Collections.emptyList( );
     }
 }

--- a/src/java/fr/paris/lutece/plugins/mylutece/modules/database/authentication/web/DatabaseJspBean.java
+++ b/src/java/fr/paris/lutece/plugins/mylutece/modules/database/authentication/web/DatabaseJspBean.java
@@ -141,8 +141,6 @@ public class DatabaseJspBean extends PluginAdminPageJspBean
     //JSP
     private static final String JSP_DO_REMOVE_USER = "jsp/admin/plugins/mylutece/modules/database/DoRemoveUser.jsp";
     private static final String JSP_MANAGE_ADVANCED_PARAMETERS = "ManageAdvancedParameters.jsp";
-    private static final String JSP_URL_MANAGE_ADVANCED_PARAMETERS = "jsp/admin/plugins/mylutece/modules/database/ManageAdvancedParameters.jsp";
-    private static final String JSP_URL_MODIFY_PASSWORD_ENCRYPTION = "jsp/admin/plugins/mylutece/modules/database/DoModifyPasswordEncryption.jsp";
     private static final String JSP_URL_MODIFY_USER = "jsp/admin/plugins/mylutece/modules/database/ModifyUser.jsp";
     private static final String JSP_URL_MANAGE_ROLES_USER = "jsp/admin/plugins/mylutece/modules/database/ManageRolesUser.jsp";
     private static final String JSP_URL_MANAGE_GROUPS_USER = "jsp/admin/plugins/mylutece/modules/database/ManageGroupsUser.jsp";
@@ -160,9 +158,6 @@ public class DatabaseJspBean extends PluginAdminPageJspBean
     private static final String PROPERTY_PAGE_TITLE_MODIFY_USER = "module.mylutece.database.modify_user.pageTitle";
     private static final String PROPERTY_PAGE_TITLE_MANAGE_ROLES_USER = "module.mylutece.database.manage_roles_user.pageTitle";
     private static final String PROPERTY_PAGE_TITLE_MANAGE_GROUPS_USER = "module.mylutece.database.manage_groups_user.pageTitle";
-    private static final String PROPERTY_MESSAGE_CONFIRM_MODIFY_PASSWORD_ENCRYPTION = "module.mylutece.database.manage_advanced_parameters.message.confirmModifyPasswordEncryption";
-    private static final String PROPERTY_MESSAGE_NO_CHANGE_PASSWORD_ENCRYPTION = "module.mylutece.database.manage_advanced_parameters.message.noChangePasswordEncryption";
-    private static final String PROPERTY_MESSAGE_INVALID_ENCRYPTION_ALGORITHM = "module.mylutece.database.manage_advanced_parameters.message.invalidEncryptionAlgorithm";
     private static final String PROPERTY_MESSAGE_CONFIRM_USE_ASP = "mylutece.manage_advanced_parameters.message.confirmUseAdvancedSecurityParameters";
     private static final String PROPERTY_MESSAGE_CONFIRM_REMOVE_ASP = "mylutece.manage_advanced_parameters.message.confirmRemoveAdvancedSecurityParameters";
     private static final String PROPERTY_MESSAGE_TITLE_CHANGE_ANONYMIZE_USER = "mylutece.anonymize_user.titleAnonymizeUser";
@@ -175,7 +170,6 @@ public class DatabaseJspBean extends PluginAdminPageJspBean
     private static final String PROPERTY_UNBLOCK_USER = "mylutece.ip.unblockUser";
     private static final String PROPERTY_NOTIFY_PASSWORD_EXPIRED = "mylutece.accountLifeTime.labelPasswordExpired";
     private static final String PROPERTY_MAIL_LOST_PASSWORD = "mylutece.accountLifeTime.labelLostPasswordMail";
-    private static final String PROPERTY_MAIL_PASSWORD_ENCRYPTION_CHANGED = "mylutece.accountLifeTime.labelPasswordEncryptionChangedMail";
     private static final String PROPERTY_IMPORT_USERS_FROM_FILE_PAGETITLE = "module.mylutece.database.import_users_from_file.pageTitle";
     private static final String PROPERTY_EXPORT_USERS_PAGETITLE = "module.mylutece.database.export_users.pageTitle";
 
@@ -203,8 +197,6 @@ public class DatabaseJspBean extends PluginAdminPageJspBean
     private static final String PARAMETER_FIRST_NAME = "first_name";
     private static final String PARAMETER_EMAIL = "email";
     private static final String PARAMETER_CANCEL = "cancel";
-    private static final String PARAMETER_ENABLE_PASSWORD_ENCRYPTION = "enable_password_encryption";
-    private static final String PARAMETER_ENCRYPTION_ALGORITHM = "encryption_algorithm";
     private static final String PARAMETER_MODIFY_USER = "modify_user";
     private static final String PARAMETER_ASSIGN_ROLE = "assign_role";
     private static final String PARAMETER_ASSIGN_GROUP = "assign_group";
@@ -238,9 +230,6 @@ public class DatabaseJspBean extends PluginAdminPageJspBean
     private static final String PARAMETER_MAIL_LOST_PASSWORD = "mylutece_database_mailLostPassword";
     private static final String PARAMETER_MAIL_LOST_PASSWORD_SENDER = "mail_lost_password_sender";
     private static final String PARAMETER_MAIL_LOST_PASSWORD_SUBJECT = "mail_lost_password_subject";
-    private static final String PARAMETER_MAIL_PASSWORD_ENCRYPTION_CHANGED = "mylutece_database_mailPasswordEncryptionChanged";
-    private static final String PARAMETER_MAIL_PASSWORD_ENCRYPTION_CHANGED_SENDER = "mail_password_encryption_changed_sender";
-    private static final String PARAMETER_MAIL_PASSWORD_ENCRYPTION_CHANGED_SUBJECT = "mail_password_encryption_changed_subject";
     private static final String PARAMETER_IMPORT_USERS_FILE = "import_file";
     private static final String PARAMETER_SKIP_FIRST_LINE = "ignore_first_line";
     private static final String PARAMETER_UPDATE_USERS = "update_existing_users";
@@ -302,7 +291,6 @@ public class DatabaseJspBean extends PluginAdminPageJspBean
     private static final String CONSTANT_EMAIL_TYPE_IP_BLOCKED = "ip_blocked";
     private static final String CONSTANT_EMAIL_PASSWORD_EXPIRED = "password_expired";
     private static final String CONSTANT_EMAIL_TYPE_LOST_PASSWORD = "lost_password";
-    private static final String CONSTANT_EMAIL_PASSWORD_ENCRYPTION_CHANGED = "password_encryption_changed";
     private static final String CONSTANT_EXTENSION_CSV_FILE = ".csv";
     private static final String CONSTANT_EXTENSION_XML_FILE = ".xml";
     private static final String CONSTANT_MIME_TYPE_CSV = "application/csv";
@@ -1032,109 +1020,6 @@ public class DatabaseJspBean extends PluginAdminPageJspBean
     }
 
     /**
-     * Returns the page of confirmation for modifying the password
-     * encryption
-     *
-     * @param request The Http Request
-     * @return the confirmation url
-     */
-    public String doConfirmModifyPasswordEncryption( HttpServletRequest request )
-    {
-        String strEnablePasswordEncryption = request.getParameter( PARAMETER_ENABLE_PASSWORD_ENCRYPTION );
-        String strEncryptionAlgorithm = request.getParameter( PARAMETER_ENCRYPTION_ALGORITHM );
-
-        strEnablePasswordEncryption = StringUtils.isNotBlank( strEnablePasswordEncryption )
-            ? strEnablePasswordEncryption : StringUtils.EMPTY;
-        strEncryptionAlgorithm = StringUtils.isNotBlank( strEncryptionAlgorithm ) ? strEncryptionAlgorithm
-                                                                                  : StringUtils.EMPTY;
-
-        boolean bEnablePasswordEncryption = Boolean.valueOf( strEnablePasswordEncryption );
-        boolean bOldEnablePasswordEncryption = _userParamService.isPasswordEncrypted( _plugin );
-        String strOldEncryptionAlgorithm = _userParamService.getEncryptionAlgorithm( _plugin );
-
-        String strUrl = StringUtils.EMPTY;
-
-        if ( ( bEnablePasswordEncryption == bOldEnablePasswordEncryption ) &&
-                strEncryptionAlgorithm.equals( strOldEncryptionAlgorithm ) )
-        {
-            strUrl = AdminMessageService.getMessageUrl( request, PROPERTY_MESSAGE_NO_CHANGE_PASSWORD_ENCRYPTION,
-                    JSP_URL_MANAGE_ADVANCED_PARAMETERS, AdminMessage.TYPE_INFO );
-        }
-        else if ( bEnablePasswordEncryption && StringUtils.isBlank( strEncryptionAlgorithm ) )
-        {
-            strUrl = AdminMessageService.getMessageUrl( request, PROPERTY_MESSAGE_INVALID_ENCRYPTION_ALGORITHM,
-                    JSP_URL_MANAGE_ADVANCED_PARAMETERS, AdminMessage.TYPE_STOP );
-        }
-        else
-        {
-            if ( !bEnablePasswordEncryption )
-            {
-                strEncryptionAlgorithm = StringUtils.EMPTY;
-            }
-
-            String strUrlModify = JSP_URL_MODIFY_PASSWORD_ENCRYPTION + "?" + PARAMETER_ENABLE_PASSWORD_ENCRYPTION +
-                "=" + strEnablePasswordEncryption + "&" + PARAMETER_ENCRYPTION_ALGORITHM + "=" +
-                strEncryptionAlgorithm;
-
-            strUrl = AdminMessageService.getMessageUrl( request, PROPERTY_MESSAGE_CONFIRM_MODIFY_PASSWORD_ENCRYPTION,
-                    strUrlModify, AdminMessage.TYPE_CONFIRMATION );
-        }
-
-        return strUrl;
-    }
-
-    /**
-     * Modify the password encryption
-     * @param request HttpServletRequest
-     * @return The Jsp URL of the process result
-     * @throws AccessDeniedException If the user does not have the permission
-     */
-    public String doModifyPasswordEncryption( HttpServletRequest request )
-        throws AccessDeniedException
-    {
-        if ( !RBACService.isAuthorized( DatabaseResourceIdService.RESOURCE_TYPE, RBAC.WILDCARD_RESOURCES_ID,
-                    DatabaseResourceIdService.PERMISSION_MANAGE, getUser(  ) ) )
-        {
-            throw new AccessDeniedException(  );
-        }
-
-        String strEnablePasswordEncryption = request.getParameter( PARAMETER_ENABLE_PASSWORD_ENCRYPTION );
-        String strEncryptionAlgorithm = request.getParameter( PARAMETER_ENCRYPTION_ALGORITHM );
-
-        strEnablePasswordEncryption = StringUtils.isNotBlank( strEnablePasswordEncryption )
-            ? strEnablePasswordEncryption : StringUtils.EMPTY;
-        strEncryptionAlgorithm = StringUtils.isNotBlank( strEncryptionAlgorithm ) ? strEncryptionAlgorithm
-                                                                                  : StringUtils.EMPTY;
-
-        boolean bEnablePasswordEncryption = Boolean.valueOf( strEnablePasswordEncryption );
-        boolean bOldEnablePasswordEncryption = _userParamService.isPasswordEncrypted( _plugin );
-        String strOldEncryptionAlgorithm = _userParamService.getEncryptionAlgorithm( _plugin );
-
-        if ( ( bEnablePasswordEncryption == bOldEnablePasswordEncryption ) &&
-                strEncryptionAlgorithm.equals( strOldEncryptionAlgorithm ) )
-        {
-            return JSP_MANAGE_ADVANCED_PARAMETERS;
-        }
-
-        ReferenceItem userParamEnablePwdEncryption = new ReferenceItem(  );
-        userParamEnablePwdEncryption.setCode( PARAMETER_ENABLE_PASSWORD_ENCRYPTION );
-        userParamEnablePwdEncryption.setName( strEnablePasswordEncryption );
-        userParamEnablePwdEncryption.setChecked( bEnablePasswordEncryption );
-
-        ReferenceItem userParamEncryptionAlgorithm = new ReferenceItem(  );
-        userParamEncryptionAlgorithm.setCode( PARAMETER_ENCRYPTION_ALGORITHM );
-        userParamEncryptionAlgorithm.setName( strEncryptionAlgorithm );
-
-        _userParamService.update( userParamEnablePwdEncryption, _plugin );
-        _userParamService.update( userParamEncryptionAlgorithm, _plugin );
-
-        _databaseService.changeUserPasswordAndNotify( AppPathService.getBaseUrl( request ), getPlugin(  ),
-            request.getLocale(  ) );
-
-        return JSP_MANAGE_ADVANCED_PARAMETERS;
-    }
-
-    /**
      * Do activate the user
      * @param request the Http
      * @return the jsp home
@@ -1511,13 +1396,6 @@ public class DatabaseJspBean extends PluginAdminPageJspBean
             strBodyKey = PARAMETER_MAIL_LOST_PASSWORD;
             strTitle = PROPERTY_MAIL_LOST_PASSWORD;
         }
-        else if ( CONSTANT_EMAIL_PASSWORD_ENCRYPTION_CHANGED.equalsIgnoreCase( strEmailType ) )
-        {
-            strSenderKey = PARAMETER_MAIL_PASSWORD_ENCRYPTION_CHANGED_SENDER;
-            strSubjectKey = PARAMETER_MAIL_PASSWORD_ENCRYPTION_CHANGED_SUBJECT;
-            strBodyKey = PARAMETER_MAIL_PASSWORD_ENCRYPTION_CHANGED;
-            strTitle = PROPERTY_MAIL_PASSWORD_ENCRYPTION_CHANGED;
-        }
 
         ReferenceItem referenceItem = _userParamService.findByKey( strSenderKey, getPlugin(  ) );
         String strSender = ( referenceItem == null ) ? StringUtils.EMPTY : referenceItem.getName(  );
@@ -1593,12 +1471,6 @@ public class DatabaseJspBean extends PluginAdminPageJspBean
             strSenderKey = PARAMETER_MAIL_LOST_PASSWORD_SENDER;
             strSubjectKey = PARAMETER_MAIL_LOST_PASSWORD_SUBJECT;
             strBodyKey = PARAMETER_MAIL_LOST_PASSWORD;
-        }
-        else if ( CONSTANT_EMAIL_PASSWORD_ENCRYPTION_CHANGED.equalsIgnoreCase( strEmailType ) )
-        {
-            strSenderKey = PARAMETER_MAIL_PASSWORD_ENCRYPTION_CHANGED_SENDER;
-            strSubjectKey = PARAMETER_MAIL_PASSWORD_ENCRYPTION_CHANGED_SUBJECT;
-            strBodyKey = PARAMETER_MAIL_PASSWORD_ENCRYPTION_CHANGED;
         }
 
         SecurityUtils.updateParameterValue( _userParamService, getPlugin(  ), strSenderKey,

--- a/src/java/fr/paris/lutece/plugins/mylutece/modules/database/resources/database_messages.properties
+++ b/src/java/fr/paris/lutece/plugins/mylutece/modules/database/resources/database_messages.properties
@@ -302,15 +302,9 @@ manage_users_group.linkManageRoles=Roles management
 
 #Manage advanced parameters
 manage_advanced_parameters.pageTitle=Advanced parameters
-manage_advanced_parameters.message.confirmModifyPasswordEncryption=Do you really want to modify the password encryption ? (The modification will reset all user's passwords)
-manage_advanced_parameters.message.noChangePasswordEncryption=No modification done
-manage_advanced_parameters.message.invalidEncryptionAlgorithm=Please choose an encryption algorithm
-manage_advanced_parameters.labelEnablePasswordEncryption=Password encryption
 manage_advanced_parameters.buttonPasswordEncryptionOn=On
 manage_advanced_parameters.buttonPasswordEncryptionOff=Off
-manage_advanced_parameters.labelEncryptionAlgorithm=Algorithm used
 manage_advanced_parameters.buttonModify=Modify
-manage_advanced_parameters.labelNoAlgorithm=&lt;No algorithm&gt;
 manage_advanced_parameters.btnManageAttributes=Attribute management
 manage_advanced_parameters.labelAccountCreationValidationEmail=Validation by email
 manage_advanced_parameters.labelAccountCreationValidationEmailComment=Check this box if you want the account creation to be validated by email

--- a/src/java/fr/paris/lutece/plugins/mylutece/modules/database/resources/database_messages_fr.properties
+++ b/src/java/fr/paris/lutece/plugins/mylutece/modules/database/resources/database_messages_fr.properties
@@ -301,15 +301,9 @@ manage_users_group.linkManageRoles=G\u00E9rer les r\u00F4les
 
 #Manage advanced parameters
 manage_advanced_parameters.pageTitle=Param\u00EAtres avanc\u00E9s
-manage_advanced_parameters.message.confirmModifyPasswordEncryption=Etes-vous s\u00FBr de vouloir modifier le cryptage des mots de passe ? (La modification r\u00E9initialisera tous les mots de passes de tous les utilisateurs)
-manage_advanced_parameters.message.noChangePasswordEncryption=Aucune modification faite
-manage_advanced_parameters.message.invalidEncryptionAlgorithm=Veuillez s\u00E9lectionner un algorithme de cryptage
-manage_advanced_parameters.labelEnablePasswordEncryption=Cryptage des mots de passe
 manage_advanced_parameters.buttonPasswordEncryptionOn=Activ\u00E9
 manage_advanced_parameters.buttonPasswordEncryptionOff=D\u00E9sactiv\u00E9
-manage_advanced_parameters.labelEncryptionAlgorithm=Algorithme utilis\u00E9
 manage_advanced_parameters.buttonModify=Modifier
-manage_advanced_parameters.labelNoAlgorithm=&lt;Aucun algorithme&gt;
 manage_advanced_parameters.btnManageAttributes=Gestion des attributs
 manage_advanced_parameters.labelAccountCreationValidationEmail=Validation par email
 manage_advanced_parameters.labelAccountCreationValidationEmailComment=Cochez cette case si vous souhaitez que la cr\u00E9ation d'un compte soit activ\u00E9e par email

--- a/src/sql/plugins/mylutece/modules/database/plugin/create_db_mylutece_database.sql
+++ b/src/sql/plugins/mylutece/modules/database/plugin/create_db_mylutece_database.sql
@@ -5,7 +5,7 @@ DROP TABLE IF EXISTS mylutece_database_user;
 CREATE TABLE mylutece_database_user (
   mylutece_database_user_id int NOT NULL,
   login varchar(100) DEFAULT '' NOT NULL,
-  password varchar(100) DEFAULT '' NOT NULL,
+  password long varchar DEFAULT '' NOT NULL,
   name_given varchar(100) DEFAULT '' NOT NULL,
   name_family varchar(100) DEFAULT '' NOT NULL,
   email varchar(100) DEFAULT NULL,
@@ -83,7 +83,7 @@ CREATE TABLE mylutece_database_key(
 DROP TABLE IF EXISTS mylutece_database_user_password_history;
 CREATE  TABLE mylutece_database_user_password_history (
   mylutece_database_user_id INT NOT NULL ,
-  password VARCHAR(100) NOT NULL ,
+  password long VARCHAR NOT NULL ,
   date_password_change TIMESTAMP NOT NULL DEFAULT NOW() ,
   PRIMARY KEY (mylutece_database_user_id, date_password_change)
 );

--- a/src/sql/plugins/mylutece/modules/database/plugin/init_db_mylutece_database.sql
+++ b/src/sql/plugins/mylutece/modules/database/plugin/init_db_mylutece_database.sql
@@ -1,8 +1,6 @@
 --
 -- Init  table mylutece_database_user_parameter
 --
-INSERT INTO mylutece_database_user_parameter VALUES ('enable_password_encryption', 'false');
-INSERT INTO mylutece_database_user_parameter VALUES ('encryption_algorithm', '');
 INSERT INTO mylutece_database_user_parameter VALUES ('account_creation_validation_email', 'false');
 INSERT INTO mylutece_database_user_parameter VALUES ('auto_login_after_validation_email', 'false');
 INSERT INTO mylutece_database_user_parameter VALUES ('enable_jcaptcha', 'false');

--- a/src/sql/plugins/mylutece/modules/database/upgrade/update_db_mylutece_database-4.0.0-5.0.0.sql
+++ b/src/sql/plugins/mylutece/modules/database/upgrade/update_db_mylutece_database-4.0.0-5.0.0.sql
@@ -1,0 +1,19 @@
+ALTER TABLE mylutece_database_user MODIFY COLUMN password LONG VARCHAR default NULL;
+ALTER TABLE mylutece_database_user_password_history MODIFY COLUMN password LONG VARCHAR default NULL;
+
+-- update password storage
+UPDATE mylutece_database_user SET password =
+ CONCAT(COALESCE(
+	(SELECT CONCAT(mdup1.parameter_value,':') FROM mylutece_database_user_parameter mdup1 CROSS JOIN mylutece_database_user_parameter mdup2 WHERE mdup1.parameter_key = 'encryption_algorithm' AND mdup2.parameter_key = 'enable_password_encryption' AND LOWER(mdup2.parameter_value) = 'true'),
+	'PLAINTEXT:')
+,password);
+
+-- updating password history with best effort to guess format
+-- for PostgreSQL, replace 'REGEXP' by '~*' and 'NOT REGEXP' by '!~*'
+UPDATE mylutece_database_user_password_history SET password = CONCAT('MD5:',password) WHERE password REGEXP '^[0-9a-f]{32}$';
+UPDATE mylutece_database_user_password_history SET password = CONCAT('SHA-1:',password) WHERE password REGEXP '^[0-9a-f]{40}$';
+UPDATE mylutece_database_user_password_history SET password = CONCAT('SHA-256:',password) WHERE password REGEXP '^[0-9a-f]{64}$';
+UPDATE mylutece_database_user_password_history SET password = CONCAT('PLAINTEXT:',password) WHERE password NOT REGEXP '^(MD5:[0-9a-f]{32}|SHA-1:[0-9a-f]{40}|SHA-256:[0-9a-f]{64})$';
+
+DELETE FROM mylutece_database_user_parameter WHERE parameter_key='enable_password_encryption';
+DELETE FROM mylutece_database_user_parameter WHERE parameter_key='encryption_algorithm';

--- a/src/test/java/fr/paris/lutece/plugins/mylutece/modules/database/authentication/business/DatabaseUserHomeTest.java
+++ b/src/test/java/fr/paris/lutece/plugins/mylutece/modules/database/authentication/business/DatabaseUserHomeTest.java
@@ -1,0 +1,89 @@
+package fr.paris.lutece.plugins.mylutece.modules.database.authentication.business;
+
+import java.math.BigInteger;
+import java.util.Random;
+
+import fr.paris.lutece.plugins.mylutece.modules.database.authentication.service.DatabasePlugin;
+import fr.paris.lutece.portal.service.plugin.Plugin;
+import fr.paris.lutece.portal.service.plugin.PluginService;
+import fr.paris.lutece.portal.service.spring.SpringContextService;
+import fr.paris.lutece.test.LuteceTestCase;
+import fr.paris.lutece.util.password.IPassword;
+
+public class DatabaseUserHomeTest extends LuteceTestCase
+{
+
+    private Plugin plugin;
+    private String strLogin;
+
+    @Override
+    protected void setUp( ) throws Exception
+    {
+        super.setUp( );
+        plugin = PluginService.getPlugin( DatabasePlugin.PLUGIN_NAME );
+        strLogin = getRandomName( );
+    }
+
+    @Override
+    protected void tearDown( ) throws Exception
+    {
+        int nKey = DatabaseUserHome.findDatabaseUserIdFromLogin( strLogin, plugin );
+        if ( nKey != 0 )
+        {
+            DatabaseUser databaseUser = DatabaseUserHome.findByPrimaryKey( nKey, plugin );
+            DatabaseUserHome.remove( databaseUser, plugin );
+        }
+        super.tearDown( );
+    }
+
+    public void testCheckPassword_upgradeStorage( )
+    {
+        final String password = "junit";
+        IPassword legacyPassword = new IPassword( )
+        {
+
+            @Override
+            public boolean isLegacy( )
+            {
+                return true;
+            }
+
+            @Override
+            public String getStorableRepresentation( )
+            {
+                return "PLAINTEXT:" + password;
+            }
+
+            @Override
+            public boolean check( String strCleartextPassword )
+            {
+                return password.equals( strCleartextPassword );
+            }
+        };
+        DatabaseUser databaseUser = new DatabaseUser( );
+        databaseUser.setLogin( strLogin );
+        databaseUser.setFirstName( strLogin );
+        databaseUser.setLastName( strLogin );
+        DatabaseUserHome.create( databaseUser, legacyPassword, plugin );
+
+        IDatabaseUserDAO dao = SpringContextService.getBean( "mylutece-database.databaseUserDAO" );
+        IPassword storedPassword = dao.loadPassword( strLogin, plugin );
+        assertTrue( storedPassword.isLegacy( ) );
+
+        assertTrue( DatabaseUserHome.checkPassword( strLogin, password, plugin ) );
+
+        storedPassword = dao.loadPassword( strLogin, plugin );
+        assertFalse( storedPassword.isLegacy( ) );
+
+        // check that the password is the same
+        assertTrue( DatabaseUserHome.checkPassword( strLogin, password, plugin ) );
+    }
+
+    private String getRandomName( )
+    {
+        Random random = new Random( );
+        BigInteger bigInt = new BigInteger( 128, random );
+        return "junit" + bigInt.toString( 36 );
+    }
+
+}

--- a/src/test/java/fr/paris/lutece/plugins/mylutece/modules/database/authentication/service/DatabaseServiceTest.java
+++ b/src/test/java/fr/paris/lutece/plugins/mylutece/modules/database/authentication/service/DatabaseServiceTest.java
@@ -1,0 +1,169 @@
+package fr.paris.lutece.plugins.mylutece.modules.database.authentication.service;
+
+import java.math.BigInteger;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import fr.paris.lutece.plugins.mylutece.modules.database.authentication.business.DatabaseUser;
+import fr.paris.lutece.plugins.mylutece.modules.database.authentication.business.DatabaseUserHome;
+import fr.paris.lutece.portal.business.rbac.AdminRole;
+import fr.paris.lutece.portal.business.rbac.AdminRoleHome;
+import fr.paris.lutece.portal.business.rbac.RBAC;
+import fr.paris.lutece.portal.business.rbac.RBACHome;
+import fr.paris.lutece.portal.business.user.AdminUser;
+import fr.paris.lutece.portal.business.user.AdminUserHome;
+import fr.paris.lutece.portal.service.plugin.Plugin;
+import fr.paris.lutece.portal.service.plugin.PluginService;
+import fr.paris.lutece.test.LuteceTestCase;
+import fr.paris.lutece.util.password.IPassword;
+
+public class DatabaseServiceTest extends LuteceTestCase
+{
+
+    private Plugin plugin;
+    private DatabaseService service;
+    String strLogin;
+    String strPassword;
+    DatabaseUser user;
+
+    @Override
+    protected void setUp( ) throws Exception
+    {
+        super.setUp( );
+        plugin = PluginService.getPlugin( DatabasePlugin.PLUGIN_NAME );
+        service = DatabaseService.getService( );
+        strLogin = getRandomName( );
+        user = new DatabaseUser( );
+        user.setLogin( strLogin );
+        user.setFirstName( strLogin );
+        user.setLastName( strLogin );
+        strPassword = "Junit";
+        service.doCreateUser( user, strPassword, plugin );
+    }
+
+    @Override
+    protected void tearDown( ) throws Exception
+    {
+        try
+        {
+            if ( user != null )
+            {
+                DatabaseUserHome.remove( user, plugin );
+            }
+        } finally
+        {
+            super.tearDown( );
+        }
+    }
+
+    public void testDoCreateUser( )
+    {
+        DatabaseUser storedUser = DatabaseUserHome.findByPrimaryKey( user.getUserId( ), plugin );
+        assertNotNull( storedUser );
+        assertTrue( DatabaseUserHome.checkPassword( strLogin, strPassword, plugin ) );
+        assertNotNull( storedUser.getAccountMaxValidDate( ) );
+        assertTrue( storedUser.getAccountMaxValidDate( ).after( new Timestamp( ( new Date( ) ).getTime( ) ) ) );
+        assertNull( storedUser.getPasswordMaxValidDate( ) );
+    }
+
+    private String getRandomName( )
+    {
+        Random random = new Random( );
+        BigInteger bigInt = new BigInteger( 128, random );
+        return "junit" + bigInt.toString( 36 );
+    }
+
+    public void testDoModifyPassword( )
+    {
+        assertTrue( DatabaseUserHome.checkPassword( strLogin, strPassword, plugin ) );
+        String strChangedPassword = "changedPassword";
+        service.doModifyPassword( user, strChangedPassword, plugin );
+        assertFalse( DatabaseUserHome.checkPassword( strLogin, strPassword, plugin ) );
+        assertTrue( DatabaseUserHome.checkPassword( strLogin, strChangedPassword, plugin ) );
+    }
+
+    public void testCheckPassword( )
+    {
+        assertTrue( DatabaseUserHome.checkPassword( strLogin, strPassword, plugin ) );
+        assertFalse( DatabaseUserHome.checkPassword( strLogin, "", plugin ) );
+        assertFalse( DatabaseUserHome.checkPassword( strLogin, "  ", plugin ) );
+        assertFalse( DatabaseUserHome.checkPassword( strLogin, "\t", plugin ) );
+        assertFalse( DatabaseUserHome.checkPassword( strLogin, "\n", plugin ) );
+        assertFalse( DatabaseUserHome.checkPassword( strLogin, strPassword.toLowerCase( ), plugin ) );
+        assertFalse( DatabaseUserHome.checkPassword( strLogin, strPassword.toUpperCase( ), plugin ) );
+    }
+
+    public void testGetManageAdvancedParameters( )
+    {
+        AdminUser adminUser = AdminUserHome.findUserByLogin( "admin" );
+        assertNotNull( "This test expects the admin BO user to exist", adminUser );
+        String roleKey = giveRights( adminUser );
+        try
+        {
+            Map<String, Object> model = service.getManageAdvancedParameters( adminUser );
+            assertNotNull( model );
+            assertTrue( model.containsKey( "is_plugin_jcatpcha_enable" ) );
+            assertTrue( model.containsKey( "account_creation_validation_email" ) );
+            assertTrue( model.containsKey( "auto_login_after_validation_email" ) );
+            assertTrue( model.containsKey( "banned_domain_names" ) );
+            // more keys added by plugin-mylutece
+        } finally
+        {
+            removeRights( adminUser, roleKey );
+        }
+    }
+
+    private void removeRights( AdminUser adminUser, String roleKey )
+    {
+        AdminUserHome.removeRoleForUser( adminUser.getUserId( ), roleKey );
+        RBACHome.removeForRoleKey( roleKey );
+        AdminRoleHome.remove( roleKey );
+    }
+
+    private String giveRights( AdminUser adminUser )
+    {
+        String roleKey = getRandomName( );
+        AdminRole role = new AdminRole( );
+        role.setKey( roleKey );
+        role.setDescription( roleKey );
+        AdminRoleHome.create( role );
+        try
+        {
+            RBAC rBAC = new RBAC( );
+            rBAC.setRoleKey( roleKey );
+            rBAC.setResourceId( RBAC.WILDCARD_RESOURCES_ID );
+            rBAC.setResourceTypeKey( DatabaseResourceIdService.RESOURCE_TYPE );
+            rBAC.setPermissionKey( DatabaseResourceIdService.PERMISSION_MANAGE );
+            RBACHome.create( rBAC );
+            AdminUserHome.createRoleForUser( adminUser.getUserId( ), roleKey );
+            adminUser.setRoles( AdminUserHome.getRolesListForUser( adminUser.getUserId( ) ) );
+        } catch ( Throwable e )
+        {
+            e.printStackTrace( );
+        }
+        return roleKey;
+    }
+
+    public void testDoInsertNewPasswordInHistory( )
+    {
+        String strNewPassword = getRandomName( );
+        service.doInsertNewPasswordInHistory( strNewPassword, user.getUserId( ), plugin );
+        List<IPassword> history = DatabaseUserHome.selectUserPasswordHistory( user.getUserId( ), plugin );
+        assertNotNull( history );
+        assertFalse( history.isEmpty( ) );
+        boolean matchFound = false;
+        for ( IPassword password : history )
+        {
+            if ( password.check( strNewPassword ) )
+            {
+                matchFound = true;
+                break;
+            }
+        }
+        assertTrue( matchFound );
+    }
+
+}

--- a/src/test/java/fr/paris/lutece/plugins/mylutece/modules/database/authentication/web/MyLuteceDatabaseAppTest.java
+++ b/src/test/java/fr/paris/lutece/plugins/mylutece/modules/database/authentication/web/MyLuteceDatabaseAppTest.java
@@ -1,0 +1,348 @@
+package fr.paris.lutece.plugins.mylutece.modules.database.authentication.web;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Random;
+
+import fr.paris.lutece.plugins.mylutece.modules.database.authentication.BaseAuthentication;
+import fr.paris.lutece.plugins.mylutece.modules.database.authentication.BaseUser;
+import fr.paris.lutece.plugins.mylutece.modules.database.authentication.business.DatabaseHome;
+import fr.paris.lutece.plugins.mylutece.modules.database.authentication.business.DatabaseUser;
+import fr.paris.lutece.plugins.mylutece.modules.database.authentication.business.DatabaseUserHome;
+import fr.paris.lutece.plugins.mylutece.modules.database.authentication.business.key.DatabaseUserKey;
+import fr.paris.lutece.plugins.mylutece.modules.database.authentication.business.key.DatabaseUserKeyHome;
+import fr.paris.lutece.plugins.mylutece.modules.database.authentication.service.DatabasePlugin;
+import fr.paris.lutece.plugins.mylutece.modules.database.authentication.service.DatabaseService;
+import fr.paris.lutece.plugins.mylutece.modules.database.authentication.service.parameter.DatabaseUserParameterService;
+import fr.paris.lutece.plugins.mylutece.util.SecurityUtils;
+import fr.paris.lutece.portal.service.plugin.Plugin;
+import fr.paris.lutece.portal.service.plugin.PluginService;
+import fr.paris.lutece.portal.service.security.SecurityService;
+import fr.paris.lutece.test.LuteceTestCase;
+import fr.paris.lutece.test.MokeHttpServletRequest;
+import fr.paris.lutece.util.ReferenceItem;
+import fr.paris.lutece.util.password.IPassword;
+
+public class MyLuteceDatabaseAppTest extends LuteceTestCase
+{
+
+    Plugin plugin;
+
+    @Override
+    protected void setUp( ) throws Exception
+    {
+        super.setUp( );
+        plugin = PluginService.getPlugin( DatabasePlugin.PLUGIN_NAME );
+    }
+
+    public void testDoCreateAccount( )
+    {
+        MokeHttpServletRequest request = new MokeHttpServletRequest( );
+        String strLogin = getRandomName( );
+        request.addMokeParameters( "plugin_name", plugin.getName( ) );
+        request.addMokeParameters( "login", strLogin );
+        request.addMokeParameters( "email", strLogin + "@junit.fr" );
+        request.addMokeParameters( "password", "junitjunit" );
+        request.addMokeParameters( "confirmation_password", "junitjunit" );
+        request.addMokeParameters( "first_name", strLogin );
+        request.addMokeParameters( "last_name", strLogin );
+
+        MyLuteceDatabaseApp app = new MyLuteceDatabaseApp( );
+
+        String url = app.doCreateAccount( request );
+        assertNotNull( url );
+        int userId = DatabaseUserHome.findDatabaseUserIdFromLogin( strLogin, plugin );
+        assertFalse( "The user has not been created", 0 == userId );
+        DatabaseUserHome.remove( DatabaseUserHome.findByPrimaryKey( userId, plugin ), plugin );
+    }
+
+    private String getRandomName( )
+    {
+        Random random = new Random( );
+        BigInteger bigInt = new BigInteger( 128, random );
+        return "junit" + bigInt.toString( 36 );
+    }
+
+    public void testDoReinitPassword_checkPasswordHistory_emptyHistory( )
+    {
+        DatabaseUser user = null;
+        DatabaseUserKey userKey = null;
+        int nOrigPasswordHistorySize = SecurityUtils.getIntegerSecurityParameter(
+                DatabaseUserParameterService.getService( ), plugin, "password_history_size" );
+        try
+        {
+            user = new DatabaseUser( );
+            String strLogin = getRandomName( );
+            user.setLogin( strLogin );
+            user.setFirstName( strLogin );
+            user.setLastName( strLogin );
+            String strPassword = "junitjunit";
+            DatabaseService.getService( ).doCreateUser( user, strPassword, plugin );
+            userKey = new DatabaseUserKey( );
+            userKey.setKey( getRandomName( ) );
+            userKey.setUserId( user.getUserId( ) );
+            DatabaseUserKeyHome.create( userKey );
+            // activate password history checks
+            ReferenceItem userParam = new ReferenceItem( );
+            userParam.setName( Integer.toString( 1 ) );
+            userParam.setCode( "password_history_size" );
+            DatabaseUserParameterService.getService( ).update( userParam, plugin );
+            MokeHttpServletRequest request = new MokeHttpServletRequest( );
+            request.addMokeParameters( "key", userKey.getKey( ) );
+            String strNewPassword = "junitjunit" + getRandomName( );
+            request.addMokeParameters( "plugin_name", plugin.getName( ) );
+            request.addMokeParameters( "password", strNewPassword );
+            request.addMokeParameters( "confirmation_password", strNewPassword );
+
+            MyLuteceDatabaseApp app = new MyLuteceDatabaseApp( );
+
+            String url = app.doReinitPassword( request );
+            assertNotNull( url );
+            assertTrue( url.contains( "action_successful" ) );
+            assertTrue( DatabaseService.getService( ).checkPassword( strLogin, strNewPassword, plugin ) );
+            List<IPassword> history = DatabaseUserHome.selectUserPasswordHistory( user.getUserId( ), plugin );
+            assertNotNull( history );
+            assertFalse( history.isEmpty( ) );
+            boolean matchFound = false;
+            for ( IPassword password : history )
+            {
+                if ( password.check( strNewPassword ) )
+                {
+                    matchFound = true;
+                    break;
+                }
+            }
+            assertTrue( matchFound );
+            userKey = DatabaseUserKeyHome.findByPrimaryKey( userKey.getKey( ) );
+            assertNull( userKey );
+        } finally
+        {
+            if ( user != null )
+            {
+                try
+                {
+                    DatabaseUserHome.remove( user, plugin );
+                } catch ( Exception e )
+                {
+                    // ignore
+                }
+            }
+            if ( userKey != null )
+            {
+                try
+                {
+                    DatabaseUserKeyHome.remove( userKey.getKey( ) );
+                } catch ( Exception e )
+                {
+                    // ignore
+                }
+            }
+            restorePasswordHistorySize( nOrigPasswordHistorySize );
+        }
+    }
+
+    public void testDoReinitPassword_checkPasswordHistory_passwordInHistory( )
+    {
+        DatabaseUser user = null;
+        DatabaseUserKey userKey = null;
+        int nOrigPasswordHistorySize = SecurityUtils.getIntegerSecurityParameter(
+                DatabaseUserParameterService.getService( ), plugin, "password_history_size" );
+        try
+        {
+            user = new DatabaseUser( );
+            String strLogin = getRandomName( );
+            user.setLogin( strLogin );
+            user.setFirstName( strLogin );
+            user.setLastName( strLogin );
+            String strPassword = "junitjunit";
+            DatabaseService.getService( ).doCreateUser( user, strPassword, plugin );
+            userKey = new DatabaseUserKey( );
+            userKey.setKey( getRandomName( ) );
+            userKey.setUserId( user.getUserId( ) );
+            DatabaseUserKeyHome.create( userKey );
+            // activate password history checks
+            ReferenceItem userParam = new ReferenceItem( );
+            userParam.setName( Integer.toString( 10 ) );
+            userParam.setCode( "password_history_size" );
+            DatabaseUserParameterService.getService( ).update( userParam, plugin );
+            String strNewPassword = "junitjunit" + getRandomName( );
+            DatabaseService.getService( ).doInsertNewPasswordInHistory( strNewPassword, user.getUserId( ), plugin );
+            int previousPasswordHistorySize = DatabaseUserHome.selectUserPasswordHistory( user.getUserId( ), plugin )
+                    .size( );
+            MokeHttpServletRequest request = new MokeHttpServletRequest( );
+            request.addMokeParameters( "plugin_name", plugin.getName( ) );
+            request.addMokeParameters( "key", userKey.getKey( ) );
+            request.addMokeParameters( "password", strNewPassword );
+            request.addMokeParameters( "confirmation_password", strNewPassword );
+
+            MyLuteceDatabaseApp app = new MyLuteceDatabaseApp( );
+
+            String url = app.doReinitPassword( request );
+            assertNotNull( url );
+            assertTrue( url.contains( "error_code" ) );
+            assertTrue( DatabaseService.getService( ).checkPassword( strLogin, strPassword, plugin ) );
+            assertEquals( previousPasswordHistorySize,
+                    DatabaseUserHome.selectUserPasswordHistory( user.getUserId( ), plugin ).size( ) );
+            userKey = DatabaseUserKeyHome.findByPrimaryKey( userKey.getKey( ) );
+            assertNotNull( userKey );
+        } finally
+        {
+            if ( user != null )
+            {
+                try
+                {
+                    DatabaseUserHome.remove( user, plugin );
+                } catch ( Exception e )
+                {
+                    // ignore
+                }
+            }
+            if ( userKey != null )
+            {
+                try
+                {
+                    DatabaseUserKeyHome.remove( userKey.getKey( ) );
+                } catch ( Exception e )
+                {
+                    // ignore
+                }
+            }
+            restorePasswordHistorySize( nOrigPasswordHistorySize );
+        }
+    }
+
+    public void testDoChangePassword_checkPasswordHistory_emptyHistory( )
+    {
+        DatabaseUser user = null;
+        int nOrigPasswordHistorySize = SecurityUtils.getIntegerSecurityParameter(
+                DatabaseUserParameterService.getService( ), plugin, "password_history_size" );
+        try
+        {
+            user = new DatabaseUser( );
+            String strLogin = getRandomName( );
+            user.setLogin( strLogin );
+            user.setFirstName( strLogin );
+            user.setLastName( strLogin );
+            String strPassword = "junitjunit";
+            DatabaseService.getService( ).doCreateUser( user, strPassword, plugin );
+            // activate password history checks
+            ReferenceItem userParam = new ReferenceItem( );
+            userParam.setName( Integer.toString( 10 ) );
+            userParam.setCode( "password_history_size" );
+            DatabaseUserParameterService.getService( ).update( userParam, plugin );
+            String strNewPassword = "junitjunit" + getRandomName( );
+            MokeHttpServletRequest request = new MokeHttpServletRequest( );
+            BaseUser loggedInUser = DatabaseHome.findLuteceUserByLogin( strLogin, plugin, new BaseAuthentication( ) );
+            SecurityService.getInstance( ).registerUser( request, loggedInUser );
+            request.addMokeParameters( "plugin_name", plugin.getName( ) );
+            request.addMokeParameters( "old_password", strPassword );
+            request.addMokeParameters( "new_password", strNewPassword );
+            request.addMokeParameters( "confirmation_password", strNewPassword );
+
+            MyLuteceDatabaseApp app = new MyLuteceDatabaseApp( );
+
+            String url = app.doChangePassword( request );
+
+            assertNotNull( url );
+            assertTrue( url.contains( "action_successful" ) );
+            assertTrue( DatabaseService.getService( ).checkPassword( strLogin, strNewPassword, plugin ) );
+            List<IPassword> history = DatabaseUserHome.selectUserPasswordHistory( user.getUserId( ), plugin );
+            assertNotNull( history );
+            assertFalse( history.isEmpty( ) );
+            boolean matchFound = false;
+            for ( IPassword password : history )
+            {
+                if ( password.check( strNewPassword ) )
+                {
+                    matchFound = true;
+                    break;
+                }
+            }
+            assertTrue( matchFound );
+        } finally
+        {
+            if ( user != null )
+            {
+                try
+                {
+                    DatabaseUserHome.remove( user, plugin );
+                } catch ( Exception e )
+                {
+                    // ignore
+                }
+            }
+            restorePasswordHistorySize( nOrigPasswordHistorySize );
+        }
+    }
+
+    public void testDoChangePassword_checkPasswordHistory_passwordInHistory( )
+    {
+        DatabaseUser user = null;
+        int nOrigPasswordHistorySize = SecurityUtils.getIntegerSecurityParameter(
+                DatabaseUserParameterService.getService( ), plugin, "password_history_size" );
+        try
+        {
+            user = new DatabaseUser( );
+            String strLogin = getRandomName( );
+            user.setLogin( strLogin );
+            user.setFirstName( strLogin );
+            user.setLastName( strLogin );
+            String strPassword = "junitjunit";
+            DatabaseService.getService( ).doCreateUser( user, strPassword, plugin );
+            // activate password history checks
+            ReferenceItem userParam = new ReferenceItem( );
+            userParam.setName( Integer.toString( 10 ) );
+            userParam.setCode( "password_history_size" );
+            DatabaseUserParameterService.getService( ).update( userParam, plugin );
+            String strNewPassword = "junitjunit" + getRandomName( );
+            DatabaseService.getService( ).doInsertNewPasswordInHistory( strNewPassword, user.getUserId( ), plugin );
+            int previousPasswordHistorySize = DatabaseUserHome.selectUserPasswordHistory( user.getUserId( ), plugin )
+                    .size( );
+            MokeHttpServletRequest request = new MokeHttpServletRequest( );
+            BaseUser loggedInUser = DatabaseHome.findLuteceUserByLogin( strLogin, plugin, new BaseAuthentication( ) );
+            SecurityService.getInstance( ).registerUser( request, loggedInUser );
+            request.addMokeParameters( "plugin_name", plugin.getName( ) );
+            request.addMokeParameters( "old_password", strPassword );
+            request.addMokeParameters( "new_password", strNewPassword );
+            request.addMokeParameters( "confirmation_password", strNewPassword );
+
+            MyLuteceDatabaseApp app = new MyLuteceDatabaseApp( );
+
+            String url = app.doChangePassword( request );
+
+            assertNotNull( url );
+            assertTrue( url.contains( "error_code" ) );
+            assertTrue( DatabaseService.getService( ).checkPassword( strLogin, strPassword, plugin ) );
+            assertEquals( previousPasswordHistorySize,
+                    DatabaseUserHome.selectUserPasswordHistory( user.getUserId( ), plugin ).size( ) );
+        } finally
+        {
+            if ( user != null )
+            {
+                try
+                {
+                    DatabaseUserHome.remove( user, plugin );
+                } catch ( Exception e )
+                {
+                    // ignore
+                }
+            }
+            restorePasswordHistorySize( nOrigPasswordHistorySize );
+        }
+    }
+
+    private void restorePasswordHistorySize( int nOrigPasswordHistorySize )
+    {
+        try
+        {
+            ReferenceItem userParam = new ReferenceItem( );
+            userParam.setName( Integer.toString( nOrigPasswordHistorySize ) );
+            userParam.setCode( "password_history_size" );
+            DatabaseUserParameterService.getService( ).update( userParam, plugin );
+        } catch ( Exception e )
+        {
+            // ignore
+        }
+    }
+
+}

--- a/webapp/WEB-INF/conf/plugins/database_context.xml
+++ b/webapp/WEB-INF/conf/plugins/database_context.xml
@@ -26,6 +26,7 @@
   <bean id="mylutece-database.databaseUserParameterService" class="fr.paris.lutece.plugins.mylutece.modules.database.authentication.service.parameter.DatabaseUserParameterService" />
   <bean id="mylutece-database.databaseService" class="fr.paris.lutece.plugins.mylutece.modules.database.authentication.service.DatabaseService">
   	<property name="databaseUserParameterService" ref="mylutece-database.databaseUserParameterService" />
+  	<property name="passwordFactory" ref="passwordFactory" />
   </bean>
   <bean id="mylutece-database.databaseUserKeyService" class="fr.paris.lutece.plugins.mylutece.modules.database.authentication.service.key.DatabaseUserKeyService" />
   <bean id="mylutece-database.databaseAnonymizationService" class="fr.paris.lutece.plugins.mylutece.modules.database.authentication.service.DatabaseAnonymizationService" />

--- a/webapp/WEB-INF/plugins/mylutece-database.xml
+++ b/webapp/WEB-INF/plugins/mylutece-database.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1" standalone="no"?><plug-in>
    <name>mylutece-database</name>
    <class>fr.paris.lutece.plugins.mylutece.modules.database.authentication.service.DatabasePlugin</class>
-   <version>4.0.1-SNAPSHOT</version>
+   <version>5.0.0-SNAPSHOT</version>
    <description>module.mylutece.database.module.description</description>
    <documentation/>
    <installation/>
@@ -12,7 +12,7 @@
    <icon-url>images/admin/skin/plugins/mylutece/mylutece.png</icon-url>
    <copyright>Copyright 2001-2014 Mairie de Paris</copyright>
    <core-version-dependency>
-		<min-core-version>4.3.0</min-core-version>
+		<min-core-version>6.0.0</min-core-version>
 		<max-core-version/>	
    </core-version-dependency>
 	

--- a/webapp/WEB-INF/templates/admin/plugins/mylutece/modules/database/advanced_parameters.html
+++ b/webapp/WEB-INF/templates/admin/plugins/mylutece/modules/database/advanced_parameters.html
@@ -23,48 +23,6 @@
 				</legend>
 			</fieldset>
 		</form>
-		<!-- PASSWORD ENCRYPTION -->
-		<form class="form-horizontal" method="post" class="form-horizontal" name="password_encryption" action="jsp/admin/plugins/mylutece/modules/database/ModifyPasswordEncryption.jsp">
-			<fieldset>
-				<legend>#i18n{portal.users.manage_advanced_parameters.labelEnablePasswordEncryption}</legend>
-				<div class="control-group">
-					<label class="control-label" for=""></label>
-					<div class="controls">
-						<label for="enable_password_encryption" class="checkbox">#i18n{module.mylutece.database.manage_advanced_parameters.labelEnablePasswordEncryption}
-							<input type="checkbox" class="checkbox" name="enable_password_encryption" value="true" <#if use_advanced_security_parameters>disabled="disabled"</#if> <#if enable_password_encryption>checked="checked"</#if> />
-						</label>
-					</div>
-				</div>
-				<#if use_advanced_security_parameters>
-					<input type="hidden" name="enable_password_encryption" value="<#if enable_password_encryption!>true<#else>false</#if>"/>
-				</#if>
-				<div class="control-group">
-					<label class="control-label" for="encryption_algorithm">#i18n{module.mylutece.database.manage_advanced_parameters.labelEncryptionAlgorithm} : </label>
-					<div class="controls">
-						<select name="encryption_algorithm" <#if use_advanced_security_parameters>disabled="disabled"</#if>>
-						<#if !encryption_algorithm?has_content>
-							<option value="" selected="selected">#i18n{module.mylutece.database.manage_advanced_parameters.labelNoAlgorithm}</option>
-						<#else>
-							<option value="">#i18n{module.mylutece.database.manage_advanced_parameters.labelNoAlgorithm}</option>
-						</#if>
-						<#list encryption_algorithms_list as algorithm>
-							<#if algorithm = encryption_algorithm>
-								<option value="${algorithm}" selected="selected">${algorithm}</option>
-							<#else>
-								<option value=${algorithm}>${algorithm}</option>
-							</#if>
-						</#list>
-						<#if use_advanced_security_parameters>
-							<input type="hidden" name="encryption_algorithm" value="${encryption_algorithm!}"/>
-						</#if>
-						</select>
-					</div>
-				</div>
-				<div class="form-actions">
-					<button type="submit" class="btn btn-primary btn-small"><i class="icon-ok icon-white"></i>&nbsp;#i18n{module.mylutece.database.manage_advanced_parameters.buttonModify}</button>
-				</div>
-			</fieldset>
-		</form>
 		<form class="form-horizontal" method="post" class="form-horizontal" name="password_global_security" action="jsp/admin/plugins/mylutece/modules/database/DoModifyDatabaseUserParameters.jsp">
 			<fieldset>
 				<legend>#i18n{portal.users.manage_advanced_parameters.securityParameters}</legend>
@@ -240,7 +198,6 @@
 							<option value="ip_blocked" >#i18n{mylutece.ip.labelIpBlocked}</option>
 							<option value="password_expired" >#i18n{mylutece.accountLifeTime.labelPasswordExpired}</option>
 	    					<option value="lost_password" >#i18n{mylutece.accountLifeTime.labelLostPasswordMail}</option>
-							<option value="password_encryption_changed" >#i18n{mylutece.accountLifeTime.labelPasswordEncryptionChangedMail}</option>
 	    				</select>
 					</div>
 				</div>

--- a/webapp/jsp/admin/plugins/mylutece/modules/database/DoModifyPasswordEncryption.jsp
+++ b/webapp/jsp/admin/plugins/mylutece/modules/database/DoModifyPasswordEncryption.jsp
@@ -1,9 +1,0 @@
-<%@ page errorPage="../../../../ErrorPage.jsp" %>
-
-<jsp:useBean id="DatabaseUser" scope="session" class="fr.paris.lutece.plugins.mylutece.modules.database.authentication.web.DatabaseJspBean" />
-
-<%
-	DatabaseUser.init( request, DatabaseUser.RIGHT_MANAGE_DATABASE_USERS ) ; 
-	response.sendRedirect( DatabaseUser.doModifyPasswordEncryption( request ) );  
-%>
-

--- a/webapp/jsp/admin/plugins/mylutece/modules/database/ModifyPasswordEncryption.jsp
+++ b/webapp/jsp/admin/plugins/mylutece/modules/database/ModifyPasswordEncryption.jsp
@@ -1,8 +1,0 @@
-<%@ page errorPage="../../../../ErrorPage.jsp" %>
-
-<jsp:useBean id="DatabaseUser" scope="session" class="fr.paris.lutece.plugins.mylutece.modules.database.authentication.web.DatabaseJspBean" />
-
-<%
-	DatabaseUser.init( request, DatabaseUser.RIGHT_MANAGE_DATABASE_USERS ) ; 
-    response.sendRedirect( DatabaseUser.doConfirmModifyPasswordEncryption( request ) ); 
-%>


### PR DESCRIPTION
Change the method to store user passwords to PBKDF2WithHmacSHA1.
To achieve this, the lutece-core infrastructure provided since
6.0.0-SNAPSHOT is used (see LUTECE-1946).
The core dependency is thus bumped.

Legacy passwords are automatically upgraded on first login.

Add tests.