### PR TITLE
MYLUTECEDATABASE-58 : Remove the password history when removing the user

### DIFF
--- a/src/java/fr/paris/lutece/plugins/mylutece/modules/database/authentication/business/DatabaseUserHome.java
+++ b/src/java/fr/paris/lutece/plugins/mylutece/modules/database/authentication/business/DatabaseUserHome.java
@@ -137,6 +137,7 @@ public final class DatabaseUserHome
     public static void remove( DatabaseUser databaseUser, Plugin plugin )
     {
         _dao.delete( databaseUser, plugin );
+        _dao.removeAllPasswordHistoryForUser( databaseUser.getUserId( ), plugin );
         LuteceUserService.userAttributesChanged( databaseUser.getLogin(  ) );
     }
 

--- a/src/sql/plugins/mylutece/modules/database/upgrade/update_db_mylutece_database-4.0.1-5.0.0.sql
+++ b/src/sql/plugins/mylutece/modules/database/upgrade/update_db_mylutece_database-4.0.1-5.0.0.sql
@@ -8,6 +8,9 @@ UPDATE mylutece_database_user SET password =
 	'PLAINTEXT:')
 ,password);
 
+-- remove obsolete password history
+DELETE FROM mylutece_database_user_password_history WHERE mylutece_database_user_id NOT IN ( SELECT mylutece_database_user_id FROM mylutece_database_user );
+
 -- updating password history with best effort to guess format
 -- for PostgreSQL, replace 'REGEXP' by '~*' and 'NOT REGEXP' by '!~*'
 UPDATE mylutece_database_user_password_history SET password = CONCAT('MD5:',password) WHERE password REGEXP '^[0-9a-f]{32}$';

--- a/src/test/java/fr/paris/lutece/plugins/mylutece/modules/database/authentication/business/DatabaseUserHomeTest.java
+++ b/src/test/java/fr/paris/lutece/plugins/mylutece/modules/database/authentication/business/DatabaseUserHomeTest.java
@@ -9,6 +9,7 @@ import fr.paris.lutece.portal.service.plugin.PluginService;
 import fr.paris.lutece.portal.service.spring.SpringContextService;
 import fr.paris.lutece.test.LuteceTestCase;
 import fr.paris.lutece.util.password.IPassword;
+import fr.paris.lutece.util.password.IPasswordFactory;
 
 public class DatabaseUserHomeTest extends LuteceTestCase
 {
@@ -77,6 +78,25 @@ public class DatabaseUserHomeTest extends LuteceTestCase
 
         // check that the password is the same
         assertTrue( DatabaseUserHome.checkPassword( strLogin, password, plugin ) );
+    }
+
+    public void testRemoveRemovesPasswordHistory( )
+    {
+        DatabaseUser databaseUser = new DatabaseUser( );
+        databaseUser.setLogin( strLogin );
+        databaseUser.setFirstName( strLogin );
+        databaseUser.setLastName( strLogin );
+        IPasswordFactory passwordFactory = SpringContextService.getBean( IPasswordFactory.BEAN_NAME );
+        DatabaseUserHome.create( databaseUser, passwordFactory.getPasswordFromCleartext( strLogin ), plugin );
+
+        DatabaseUserHome.insertNewPasswordInHistory( passwordFactory.getPasswordFromCleartext( strLogin + "_2" ),
+                databaseUser.getUserId( ), plugin );
+
+        assertEquals( 1, DatabaseUserHome.selectUserPasswordHistory( databaseUser.getUserId( ), plugin ).size( ) );
+
+        DatabaseUserHome.remove( databaseUser, plugin );
+
+        assertEquals( 0, DatabaseUserHome.selectUserPasswordHistory( databaseUser.getUserId( ), plugin ).size( ) );
     }
 
     private String getRandomName( )


### PR DESCRIPTION
Remove orphaned password history when upgrading the DB.
Add a test.
This should fix the test MyLuteceDatabaseAppTest#testDoChangePassword_checkPasswordHistory_passwordInHistory when
run on databases whose time resolution is low (to the second for MySQL)